### PR TITLE
fix(pretty-error): fix position of column indicator

### DIFF
--- a/lib/formatters/pretty-error.js
+++ b/lib/formatters/pretty-error.js
@@ -11,11 +11,11 @@ var stringWidth = require("../stringWidth");
 var widthOfString = stringWidth({ambiguousEastAsianCharWidth: 2});
 var template = style('{grey}{ruleId}: {bold}{red}{title}\n'
     + '{grey}{filename}{reset}\n'
-    + '    {red}  {v}\n'
+    + '    {red}{paddingForLineNo}  {v}\n'
     + '    {grey}{previousLineNo}. {previousLine}\n'
     + '    {reset}{failingLineNo}. {failingLine}\n'
     + '    {grey}{nextLineNo}. {nextLine}\n'
-    + '    {red}  {^}{reset}\n'
+    + '    {red}{paddingForLineNo}  {^}{reset}\n'
     + '{reset}');
 
 
@@ -53,7 +53,7 @@ function showColumn(codes, ch) {
     var result = '';
     var codeObject = codes[1];
     var sliced = codeObject.code.slice(0, codeObject.col);
-    var i = widthOfString(sliced) + 1;
+    var i = widthOfString(sliced) - 1;
 
     while (i--) {
         result += ' ';
@@ -91,6 +91,7 @@ function prettyError(code, filePath, message) {
         nextLine: parsed[2].code ? parsed[2].code : "",
         nextLineNo: leftpad(nextLineNo, linumlen),
         nextColNo: parsed[2].col,
+        paddingForLineNo: leftpad('', linumlen),
         '^': showColumn(parsed, '^'),
         'v': showColumn(parsed, 'v')
     });


### PR DESCRIPTION
In pretty-error, column indicators, `v` and `^`, point out wrong column depending on the width of line number.
## Fixture

``` sh
$ cat /tmp/test.md | grep -n '\[ \]'
7:- [ ]  more more document
19:- [ ]  more more document
108:- [ ]  more more document
```
## Before

Indicators point out wrong column when the width of line number != 2.

``` sh
$ textlint --rule no-todo -f pretty-error /tmp/test.md
no-todo: found TODO: '- [ ]  more more document'
/tmp/test.md:7:1
        v
    6.
    7. - [ ]  more more document
    8.
        ^

no-todo: found TODO: '- [ ]  more more document'
/tmp/test.md:19:1
        v
    18.
    19. - [ ]  more more document
    20.
        ^

no-todo: found TODO: '- [ ]  more more document'
/tmp/test.md:108:1
        v
    107.
    108. - [ ]  more more document
    109.
        ^
```
## After

Indicators point out correct column.

``` sh
$ textlint --rule no-todo --format pretty-error /tmp/test.md
no-todo: found TODO: '- [ ]  more more document'
/tmp/test.md:7:1
       v
    6.
    7. - [ ]  more more document
    8.
       ^

no-todo: found TODO: '- [ ]  more more document'
/tmp/test.md:19:1
        v
    18.
    19. - [ ]  more more document
    20.
        ^

no-todo: found TODO: '- [ ]  more more document'
/tmp/test.md:108:1
         v
    107.
    108. - [ ]  more more document
    109.
         ^
```
