### PR TITLE
Fix alignment of stylish format

### DIFF
--- a/lib/formatters/stylish.js
+++ b/lib/formatters/stylish.js
@@ -5,7 +5,10 @@
 "use strict";
 
 var chalk = require("chalk"),
-    table = require("text-table");
+    table = require("text-table"),
+    stringWidth = require("../stringWidth");
+
+var widthOfString = stringWidth({ambiguousEastAsianCharWidth: 2});
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -68,7 +71,7 @@ module.exports = function(results) {
                 {
                     align: ["", "r", "l"],
                     stringLength: function(str) {
-                        return chalk.stripColor(str).length;
+                        return widthOfString(chalk.stripColor(str));
                     }
                 }
             ).split("\n").map(function(el) {

--- a/lib/formatters/stylish.js
+++ b/lib/formatters/stylish.js
@@ -71,7 +71,10 @@ module.exports = function(results) {
                 {
                     align: ["", "r", "l"],
                     stringLength: function(str) {
-                        return widthOfString(chalk.stripColor(str));
+                        var lines = chalk.stripColor(str).split("\n");
+                        return Math.max.apply(null, lines.map(function(line) {
+                            return widthOfString(line);
+                        }));
                     }
                 }
             ).split("\n").map(function(el) {


### PR DESCRIPTION
There are two problems in alignment of stylish format:
- Rule names are not aligned well when error message contains full-width characters.
- Error message is too wide if it contains line breaks.
## Fixture

```
$ cat /tmp/test_japanese.md
これは、点の数が、多い、文章です。
それが事件の発端だったといえなくもない。
材料不足で代替素材で製品を作った。
しかし、〜。
だが、〜。
しかし、〜。
Say Java Script!
結果として「である」調と「ですます」調の使われる数をだしたものである。
```
## Before

<img width="1004" alt="before" src="https://cloud.githubusercontent.com/assets/532251/12450373/bee4765a-bfc6-11e5-907b-d6ac17488416.png">
## After

<img width="1004" alt="after" src="https://cloud.githubusercontent.com/assets/532251/12450382/c9ecd72c-bfc6-11e5-9653-b2505c86cd68.png">
