### PR TITLE
feat(stylish|pretty-error): add fixable results

### DIFF
--- a/lib/formatters/pretty-error.js
+++ b/lib/formatters/pretty-error.js
@@ -6,6 +6,7 @@
 var format = require("format-text");
 var leftpad = require("left-pad");
 var style = require("style-format");
+var stripAnsi = require("strip-ansi");
 var stringWidth = require("../stringWidth");
 // width is 2
 var widthOfString = stringWidth({ambiguousEastAsianCharWidth: 2});
@@ -100,9 +101,12 @@ function prettyError(code, filePath, message) {
 /**
  *
  * @param {[TextLintResult]} results
+ * @param {TextLintFormatterOption} options
  * @returns {string}
  */
-function formatter(results) {
+function formatter(results, options) {
+    var safeOptions = typeof options !== undefined ? options : {};
+    var noColor = safeOptions.noColor !== undefined ? safeOptions.noColor : false;
     var output = "";
     results.forEach(function (result) {
         var code = require("fs").readFileSync(result.filePath, "utf-8");
@@ -114,6 +118,9 @@ function formatter(results) {
         });
     });
 
+    if (noColor) {
+        return stripAnsi(output);
+    }
     return output;
 }
 module.exports = formatter;

--- a/lib/formatters/pretty-error.js
+++ b/lib/formatters/pretty-error.js
@@ -105,8 +105,7 @@ function prettyError(code, filePath, message) {
  * @returns {string}
  */
 function formatter(results, options) {
-    var safeOptions = typeof options !== undefined ? options : {};
-    var noColor = safeOptions.noColor !== undefined ? safeOptions.noColor : false;
+    var noColor = options.noColor !== undefined ? options.noColor : false;
     var output = "";
     results.forEach(function (result) {
         var code = require("fs").readFileSync(result.filePath, "utf-8");
@@ -117,7 +116,7 @@ function formatter(results, options) {
             }
         });
     });
-
+    // --no-color 
     if (noColor) {
         return stripAnsi(output);
     }

--- a/lib/formatters/stylish.js
+++ b/lib/formatters/stylish.js
@@ -52,7 +52,7 @@ module.exports = function (results) {
                 messages.map(function (message) {
                     var messageType;
                     // fixable
-                    var fixableIcon = message.fix ? chalk[greenColor].bold("\u2713") : "";
+                    var fixableIcon = message.fix ? chalk[greenColor].bold("\u2713 ") : "";
                     if (message.fix) {
                         totalFixable++;
                     }

--- a/lib/formatters/stylish.js
+++ b/lib/formatters/stylish.js
@@ -36,6 +36,7 @@ module.exports = function (results) {
     var errors = 0;
     var warnings = 0;
     var summaryColor = "yellow";
+    var greenColor = "green";
 
     results.forEach(function (result) {
         var messages = result.messages;
@@ -51,7 +52,7 @@ module.exports = function (results) {
                 messages.map(function (message) {
                     var messageType;
                     // fixable
-                    var fixableIcon = message.fix ? "\u2713" : "";
+                    var fixableIcon = message.fix ? chalk[greenColor].bold("\u2713") : "";
                     if (message.fix) {
                         totalFixable++;
                     }
@@ -98,7 +99,7 @@ module.exports = function (results) {
     }
 
     if (totalFixable > 0) {
-        output += "✓ " + totalFixable + " fixable " + pluralize("problem", totalFixable) +".\n";
+        output += chalk[greenColor].bold("✓ " + totalFixable + " fixable " + pluralize("problem", totalFixable) +".\n");
         output += "Try to run: $ " + chalk.underline("textlint --fix") +"\n";
     }
 

--- a/lib/formatters/stylish.js
+++ b/lib/formatters/stylish.js
@@ -100,7 +100,7 @@ module.exports = function (results) {
 
     if (totalFixable > 0) {
         output += chalk[greenColor].bold("✓ " + totalFixable + " fixable " + pluralize("problem", totalFixable) +".\n");
-        output += "Try to run: $ " + chalk.underline("textlint --fix") +"\n";
+        output += "Try to run: $ " + chalk.underline("textlint --fix [file]") +"\n";
     }
 
     return total > 0 ? output : "";

--- a/lib/textlint-formatter.js
+++ b/lib/textlint-formatter.js
@@ -3,13 +3,20 @@
 var fs = require("fs");
 var path = require("path");
 var tryResolve = require('try-resolve');
+
+/** @typedef {Object} TextLintFormatterOption
+ *  @property {string} formatterName
+ *  @property {boolean} noColor
+ */
+
 /**
  * Create formatter function from {@link options}
- * @param {object} options
+ * @param {TextLintFormatterOption} options
  * @returns {Function} the returned Function is formatter
  */
 function createFormatter(options) {
     var formatName = options.formatterName;
+    var noColor = options.noColor !== undefined ? options.noColor : false;
     var formatterPath;
     if (fs.existsSync(formatName)) {
         formatterPath = formatName;
@@ -28,6 +35,8 @@ function createFormatter(options) {
     } catch (ex) {
         throw new Error("Could not find formatter " + formatName + "\n" + ex);
     }
-    return formatter;
+    return function (results) {
+        return formatter(results, options);
+    };
 }
 module.exports = createFormatter;

--- a/lib/textlint-formatter.js
+++ b/lib/textlint-formatter.js
@@ -1,6 +1,7 @@
 // LICENSE : MIT
 "use strict";
 var fs = require("fs");
+var assert = require("assert");
 var path = require("path");
 var tryResolve = require('try-resolve');
 
@@ -15,6 +16,7 @@ var tryResolve = require('try-resolve');
  * @returns {Function} the returned Function is formatter
  */
 function createFormatter(options) {
+    assert(typeof options === "object", "options should be object");
     var formatName = options.formatterName;
     var noColor = options.noColor !== undefined ? options.noColor : false;
     var formatterPath;
@@ -36,7 +38,9 @@ function createFormatter(options) {
         throw new Error("Could not find formatter " + formatName + "\n" + ex);
     }
     return function (results) {
-        return formatter(results, options);
+        return formatter(results, {
+            noColor: noColor
+        });
     };
 }
 module.exports = createFormatter;

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "js-yaml": "^3.2.4",
     "left-pad": "0.0.4",
     "pluralize": "^1.2.1",
+    "strip-ansi": "^3.0.1",
     "style-format": "0.0.0",
     "table": "^3.7.8",
     "text-table": "^0.2.0",

--- a/test/fixtures/bar.md
+++ b/test/fixtures/bar.md
@@ -1,0 +1,6 @@
+1st line
+2nd line
+3rd line
+4th line
+5th line foo
+6th line

--- a/test/fixtures/ckj.md
+++ b/test/fixtures/ckj.md
@@ -1,0 +1,3 @@
+1st line
+日本語 中国語 English！
+3rd line

--- a/test/fixtures/foo.md
+++ b/test/fixtures/foo.md
@@ -1,0 +1,6 @@
+1st line
+2nd line
+3rd line
+4th line
+5th line foo
+6th line

--- a/test/formatters/pretty-error-test.js
+++ b/test/formatters/pretty-error-test.js
@@ -1,0 +1,124 @@
+// LICENSE : MIT
+"use strict";
+var assert = require("power-assert");
+var path = require("path");
+var prettyError = require("../../lib/formatters/pretty-error");
+var stripAnsi = require("strip-ansi");
+describe("pretty-error", function () {
+    context("when first line", function () {
+
+        it("should start 0 line", function () {
+            const fooFile = path.join(__dirname, "../fixtures", "foo.md");
+            var code = [
+                {
+                    filePath: fooFile,
+                    messages: [
+                        {
+                            message: "Unexpected foo.",
+                            severity: 2,
+                            line: 1,
+                            column: 1,
+                            ruleId: "foo",
+                            source: "foo"
+                        }
+                    ]
+                }
+            ];
+            var output = stripAnsi(prettyError(code));
+            assert.equal(output, `foo: Unexpected foo.
+${fooFile}:1:1
+       v
+    0. 
+    1. 1st line
+    2. 2nd line
+       ^
+
+`);
+        });
+    });
+
+    context("when middle", function () {
+
+        it("should return output", function () {
+            const fooFile = path.join(__dirname, "../fixtures", "foo.md");
+            const barFile = path.join(__dirname, "../fixtures", "bar.md");
+            var code = [
+                {
+                    filePath: fooFile,
+                    messages: [
+                        {
+                            message: "Unexpected foo.",
+                            severity: 2,
+                            line: 5,
+                            column: 10,
+                            ruleId: "foo",
+                            source: "foo"
+                        }
+                    ]
+                }, {
+                    filePath: barFile,
+                    messages: [
+                        {
+                            message: "Unexpected bar.",
+                            severity: 1,
+                            line: 6,
+                            column: 11,
+                            ruleId: "bar",
+                            source: "bar"
+                        }
+                    ]
+                }
+            ];
+            var output = stripAnsi(prettyError(code));
+            assert.equal(output, `foo: Unexpected foo.
+${fooFile}:5:10
+                v
+    4. 4th line
+    5. 5th line foo
+    6. 6th line
+                ^
+
+bar: Unexpected bar.
+${barFile}:6:11
+              v
+    5. 5th line foo
+    6. 6th line
+    7. 
+              ^
+
+`);
+        });
+    });
+    context("when last line", function () {
+
+        it("should contain end+1 line", function () {
+            const fooFile = path.join(__dirname, "../fixtures", "foo.md");
+            var code = [
+                {
+                    filePath: fooFile,
+                    messages: [
+                        {
+                            message: "Unexpected foo.",
+                            severity: 2,
+                            line: 6,
+                            column: 1,
+                            ruleId: "foo",
+                            source: "foo"
+                        }
+                    ]
+                }
+            ];
+            var output = stripAnsi(prettyError(code));
+            assert.equal(output, `foo: Unexpected foo.
+${fooFile}:6:1
+       v
+    5. 5th line foo
+    6. 6th line
+    7. 
+       ^
+
+`);
+        });
+    });
+
+});

--- a/test/formatters/pretty-error-test.js
+++ b/test/formatters/pretty-error-test.js
@@ -24,7 +24,9 @@ describe("pretty-error", function () {
                     ]
                 }
             ];
-            var output = stripAnsi(prettyError(code));
+            var output = prettyError(code, {
+                noColor: true
+            });
             assert.equal(output, `foo: Unexpected foo.
 ${fooFile}:1:1
        v
@@ -69,7 +71,9 @@ ${fooFile}:1:1
                     ]
                 }
             ];
-            var output = stripAnsi(prettyError(code));
+            var output = prettyError(code, {
+                noColor: true
+            });
             assert.equal(output, `foo: Unexpected foo.
 ${fooFile}:5:10
                 v
@@ -108,7 +112,9 @@ ${barFile}:6:11
                     ]
                 }
             ];
-            var output = stripAnsi(prettyError(code));
+            var output = prettyError(code, {
+                noColor: true
+            });
             assert.equal(output, `foo: Unexpected foo.
 ${fooFile}:6:1
        v

--- a/test/formatters/pretty-error-test.js
+++ b/test/formatters/pretty-error-test.js
@@ -35,11 +35,12 @@ ${fooFile}:1:1
     2. 2nd line
        ^
 
+\u2716 1 problem (1 error, 0 warnings)
 `);
         });
     });
 
-    context("when middle", function () {
+    context("when contain fixable", function () {
 
         it("should return output", function () {
             const fooFile = path.join(__dirname, "../fixtures", "foo.md");
@@ -54,7 +55,10 @@ ${fooFile}:1:1
                             line: 5,
                             column: 10,
                             ruleId: "foo",
-                            source: "foo"
+                            fix: {
+                                range: [40, 45],
+                                text: "fixed 1"
+                            }
                         }
                     ]
                 }, {
@@ -64,9 +68,13 @@ ${fooFile}:1:1
                             message: "Unexpected bar.",
                             severity: 1,
                             line: 6,
-                            column: 11,
+                            column: 1,
                             ruleId: "bar",
-                            source: "bar"
+                            fix: {
+                                range: [50, 55],
+                                text: "fixed 2"
+                            }
+
                         }
                     ]
                 }
@@ -74,7 +82,7 @@ ${fooFile}:1:1
             var output = prettyError(code, {
                 noColor: true
             });
-            assert.equal(output, `foo: Unexpected foo.
+            assert.equal(output, `✓ foo: Unexpected foo.
 ${fooFile}:5:10
                 v
     4. 4th line
@@ -82,14 +90,17 @@ ${fooFile}:5:10
     6. 6th line
                 ^
 
-bar: Unexpected bar.
-${barFile}:6:11
-              v
+✓ bar: Unexpected bar.
+${barFile}:6:1
+       v
     5. 5th line foo
     6. 6th line
     7. 
-              ^
+       ^
 
+\u2716 2 problems (1 error, 1 warning)
+\u2713 2 fixable problems.
+Try to run: $ textlint --fix [file]
 `);
         });
     });
@@ -123,8 +134,80 @@ ${fooFile}:6:1
     7. 
        ^
 
+\u2716 1 problem (1 error, 0 warnings)
 `);
         });
     });
+    context("when last line", function () {
 
+        it("should contain end+1 line", function () {
+            const fooFile = path.join(__dirname, "../fixtures", "foo.md");
+            var code = [
+                {
+                    filePath: fooFile,
+                    messages: [
+                        {
+                            message: "Unexpected foo.",
+                            severity: 2,
+                            line: 6,
+                            column: 1,
+                            ruleId: "foo",
+                            source: "foo"
+                        }
+                    ]
+                }
+            ];
+            var output = prettyError(code, {
+                noColor: true
+            });
+            assert.equal(output, `foo: Unexpected foo.
+${fooFile}:6:1
+       v
+    5. 5th line foo
+    6. 6th line
+    7. 
+       ^
+
+\u2716 1 problem (1 error, 0 warnings)
+`);
+        });
+    });
+    context("when CKJ(東アジア文字幅)", function () {
+        it("should correct position ^", function () {
+            const ckjFile = path.join(__dirname, "../fixtures", "ckj.md");
+            var code = [
+                {
+                    filePath: ckjFile,
+                    messages: [
+                        {
+                            message: "Unexpected foo.",
+                            severity: 2,
+                            line: 2,
+                            column: 16,
+                            ruleId: "foo",
+                            fix: {
+                                range: [40, 45],
+                                text: "fixed 1"
+                            }
+                        }
+                    ]
+                }
+            ];
+            var output = prettyError(code, {
+                noColor: true
+            });
+            assert.equal(output, `✓ foo: Unexpected foo.
+${ckjFile}:2:16
+                             v
+    1. 1st line
+    2. 日本語 中国語 English！
+    3. 3rd line
+                             ^
+
+\u2716 1 problem (1 error, 0 warnings)
+\u2713 1 fixable problem.
+Try to run: $ textlint --fix [file]
+`);
+        });
+    })
 });

--- a/test/formatters/stylish.js
+++ b/test/formatters/stylish.js
@@ -9,22 +9,22 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-var assert = require("power-assert"),
-    chalk = require("chalk"),
-    proxyquire = require("proxyquire"),
-    sinon = require("sinon");
+var assert = require("power-assert");
+var chalk = require("chalk");
+var proxyquire = require("proxyquire");
+var sinon = require("sinon");
 
 // Chalk protects its methods so we need to inherit from it
 // for Sinon to work.
 var chalkStub = Object.create(chalk, {
     yellow: {
-        value: function(str) {
+        value: function (str) {
             return chalk.yellow(str);
         },
         writable: true
     },
     red: {
-        value: function(str) {
+        value: function (str) {
             return chalk.red(str);
         },
         writable: true
@@ -33,35 +33,37 @@ var chalkStub = Object.create(chalk, {
 chalkStub.yellow.bold = chalk.yellow.bold;
 chalkStub.red.bold = chalk.red.bold;
 
-var formatter = proxyquire("../../lib/formatters/stylish", { chalk: chalkStub });
+var formatter = proxyquire("../../lib/formatters/stylish", {chalk: chalkStub});
 
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
 
-describe("formatter:stylish", function() {
+describe("formatter:stylish", function () {
     var sandbox,
         colorsEnabled = chalk.enabled;
 
-    beforeEach(function() {
+    beforeEach(function () {
         chalk.enabled = false;
         sandbox = sinon.sandbox.create();
         sandbox.spy(chalkStub.yellow, "bold");
         sandbox.spy(chalkStub.red, "bold");
     });
 
-    afterEach(function() {
+    afterEach(function () {
         sandbox.verifyAndRestore();
         chalk.enabled = colorsEnabled;
     });
 
-    describe("when passed no messages", function() {
-        var code = [{
-            filePath: "foo.js",
-            messages: []
-        }];
+    describe("when passed no messages", function () {
+        var code = [
+            {
+                filePath: "foo.js",
+                messages: []
+            }
+        ];
 
-        it("should not return message", function() {
+        it("should not return message", function () {
             var result = formatter(code);
             assert.equal(result, "");
             assert.equal(chalkStub.yellow.bold.callCount, 0);
@@ -69,26 +71,30 @@ describe("formatter:stylish", function() {
         });
     });
 
-    describe("when passed a single message", function() {
-        var code = [{
-            filePath: "foo.js",
-            messages: [{
-                message: "Unexpected foo.",
-                severity: 2,
-                line: 5,
-                column: 10,
-                ruleId: "foo"
-            }]
-        }];
+    describe("when passed a single message", function () {
+        var code = [
+            {
+                filePath: "foo.js",
+                messages: [
+                    {
+                        message: "Unexpected foo.",
+                        severity: 2,
+                        line: 5,
+                        column: 10,
+                        ruleId: "foo"
+                    }
+                ]
+            }
+        ];
 
-        it("should return a string in the correct format for errors", function() {
+        it("should return a string in the correct format for errors", function () {
             var result = formatter(code);
             assert.equal(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem (1 error, 0 warnings)\n");
             assert.equal(chalkStub.yellow.bold.callCount, 0);
             assert.equal(chalkStub.red.bold.callCount, 1);
         });
 
-        it("should return a string in the correct format for warnings", function() {
+        it("should return a string in the correct format for warnings", function () {
             code[0].messages[0].severity = 1;
             var result = formatter(code);
             assert.equal(result, "\nfoo.js\n  5:10  warning  Unexpected foo  foo\n\n\u2716 1 problem (0 errors, 1 warning)\n");
@@ -97,19 +103,23 @@ describe("formatter:stylish", function() {
         });
     });
 
-    describe("when passed a fatal error message", function() {
-        var code = [{
-            filePath: "foo.js",
-            messages: [{
-                fatal: true,
-                message: "Unexpected foo.",
-                line: 5,
-                column: 10,
-                ruleId: "foo"
-            }]
-        }];
+    describe("when passed a fatal error message", function () {
+        var code = [
+            {
+                filePath: "foo.js",
+                messages: [
+                    {
+                        fatal: true,
+                        message: "Unexpected foo.",
+                        line: 5,
+                        column: 10,
+                        ruleId: "foo"
+                    }
+                ]
+            }
+        ];
 
-        it("should return a string in the correct format", function() {
+        it("should return a string in the correct format", function () {
             var result = formatter(code);
             assert.equal(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem (1 error, 0 warnings)\n");
             assert.equal(chalkStub.yellow.bold.callCount, 0);
@@ -117,25 +127,29 @@ describe("formatter:stylish", function() {
         });
     });
 
-    describe("when passed multiple messages", function() {
-        var code = [{
-            filePath: "foo.js",
-            messages: [{
-                message: "Unexpected foo.",
-                severity: 2,
-                line: 5,
-                column: 10,
-                ruleId: "foo"
-            }, {
-                message: "Unexpected bar.",
-                severity: 1,
-                line: 6,
-                column: 11,
-                ruleId: "bar"
-            }]
-        }];
+    describe("when passed multiple messages", function () {
+        var code = [
+            {
+                filePath: "foo.js",
+                messages: [
+                    {
+                        message: "Unexpected foo.",
+                        severity: 2,
+                        line: 5,
+                        column: 10,
+                        ruleId: "foo"
+                    }, {
+                        message: "Unexpected bar.",
+                        severity: 1,
+                        line: 6,
+                        column: 11,
+                        ruleId: "bar"
+                    }
+                ]
+            }
+        ];
 
-        it("should return a string with multiple entries", function() {
+        it("should return a string with multiple entries", function () {
             var result = formatter(code);
             assert.equal(result, "\nfoo.js\n  5:10  error    Unexpected foo  foo\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems (1 error, 1 warning)\n");
             assert.equal(chalkStub.yellow.bold.callCount, 0);
@@ -143,28 +157,34 @@ describe("formatter:stylish", function() {
         });
     });
 
-    describe("when passed multiple files with 1 message each", function() {
-        var code = [{
-            filePath: "foo.js",
-            messages: [{
-                message: "Unexpected foo.",
-                severity: 2,
-                line: 5,
-                column: 10,
-                ruleId: "foo"
-            }]
-        }, {
-            filePath: "bar.js",
-            messages: [{
-                message: "Unexpected bar.",
-                severity: 1,
-                line: 6,
-                column: 11,
-                ruleId: "bar"
-            }]
-        }];
+    describe("when passed multiple files with 1 message each", function () {
+        var code = [
+            {
+                filePath: "foo.js",
+                messages: [
+                    {
+                        message: "Unexpected foo.",
+                        severity: 2,
+                        line: 5,
+                        column: 10,
+                        ruleId: "foo"
+                    }
+                ]
+            }, {
+                filePath: "bar.js",
+                messages: [
+                    {
+                        message: "Unexpected bar.",
+                        severity: 1,
+                        line: 6,
+                        column: 11,
+                        ruleId: "bar"
+                    }
+                ]
+            }
+        ];
 
-        it("should return a string with multiple entries", function() {
+        it("should return a string with multiple entries", function () {
             var result = formatter(code);
             assert.equal(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\nbar.js\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems (1 error, 1 warning)\n");
             assert.equal(chalkStub.yellow.bold.callCount, 0);
@@ -172,16 +192,68 @@ describe("formatter:stylish", function() {
         });
     });
 
-    describe("when passed one file not found message", function() {
-        var code = [{
-            filePath: "foo.js",
-            messages: [{
-                fatal: true,
-                message: "Couldn't find foo.js."
-            }]
-        }];
+    describe("when passed multiple files with 1 message each and fixable", function () {
+        var code = [
+            {
+                filePath: "foo.js",
+                messages: [
+                    {
+                        message: "Unexpected foo.",
+                        severity: 2,
+                        line: 5,
+                        column: 10,
+                        ruleId: "foo",
+                        fix: {
+                            range: [40, 45],
+                            text: "fixed 1"
+                        }
+                    }
+                ]
+            }, {
+                filePath: "bar.js",
+                messages: [
+                    {
+                        message: "Unexpected bar.",
+                        severity: 1,
+                        line: 6,
+                        column: 11,
+                        ruleId: "bar",
+                        fix: {
+                            range: [50, 55],
+                            text: "fixed 2"
+                        }
 
-        it("should return a string without line and column", function() {
+                    }
+                ]
+            }
+        ];
+
+        it("should return a string with multiple entries", function () {
+            var result = formatter(code);
+            assert.equal(result, "\nfoo.js\n  " +
+                "5:10  \u2713error  Unexpected foo  foo\n\nbar.js\n  " +
+                "6:11  \u2713warning  Unexpected bar  bar\n\n" +
+                "\u2716 2 problems (1 error, 1 warning)\n" +
+                "\u2713 2 fixable problems.\n" +
+                "Try to run: $ textlint --fix\n");
+            assert.equal(chalkStub.yellow.bold.callCount, 0);
+            assert.equal(chalkStub.red.bold.callCount, 1);
+        });
+    });
+    describe("when passed one file not found message", function () {
+        var code = [
+            {
+                filePath: "foo.js",
+                messages: [
+                    {
+                        fatal: true,
+                        message: "Couldn't find foo.js."
+                    }
+                ]
+            }
+        ];
+
+        it("should return a string without line and column", function () {
             var result = formatter(code);
             assert.equal(result, "\nfoo.js\n  0:0  error  Couldn't find foo.js\n\n\u2716 1 problem (1 error, 0 warnings)\n");
             assert.equal(chalkStub.yellow.bold.callCount, 0);

--- a/test/formatters/stylish.js
+++ b/test/formatters/stylish.js
@@ -235,7 +235,7 @@ describe("formatter:stylish", function () {
                 "6:11  \u2713 warning  Unexpected bar  bar\n\n" +
                 "\u2716 2 problems (1 error, 1 warning)\n" +
                 "\u2713 2 fixable problems.\n" +
-                "Try to run: $ textlint --fix\n");
+                "Try to run: $ textlint --fix [file]\n");
             assert.equal(chalkStub.yellow.bold.callCount, 0);
             assert.equal(chalkStub.red.bold.callCount, 1);
         });

--- a/test/formatters/stylish.js
+++ b/test/formatters/stylish.js
@@ -231,8 +231,8 @@ describe("formatter:stylish", function () {
         it("should return a string with multiple entries", function () {
             var result = formatter(code);
             assert.equal(result, "\nfoo.js\n  " +
-                "5:10  \u2713error  Unexpected foo  foo\n\nbar.js\n  " +
-                "6:11  \u2713warning  Unexpected bar  bar\n\n" +
+                "5:10  \u2713 error  Unexpected foo  foo\n\nbar.js\n  " +
+                "6:11  \u2713 warning  Unexpected bar  bar\n\n" +
                 "\u2716 2 problems (1 error, 1 warning)\n" +
                 "\u2713 2 fixable problems.\n" +
                 "Try to run: $ textlint --fix\n");


### PR DESCRIPTION
We already have fixable rule.

It show fixable mark✓ on the linting results.
![javascript-plugin-architecture - webstorm ws-145 18 2016-03-08 01-11-09](https://cloud.githubusercontent.com/assets/19714/13575150/a7ef6008-e4ca-11e5-8976-053693421964.png)

What' is fixable https://github.com/textlint/textlint/issues/124

FIX https://github.com/textlint/textlint/issues/105
